### PR TITLE
Замер читает логи и на Windows, а не только на POSIX-путях

### DIFF
--- a/tools/measure-run.py
+++ b/tools/measure-run.py
@@ -11,7 +11,8 @@
     python3 tools/measure-run.py ~/Documents/VScode/EDU/share
 
 Каталог логов вычисляется из пути проекта так же, как это делает Claude Code:
-слэши заменяются дефисами внутри ~/.claude/projects/.
+разделители пути заменяются дефисами внутри ~/.claude/projects/
+(на Windows — обратные слэши и двоеточие диска тоже).
 
 Нормировка стоимости — относительно входного токена:
     output ×5 · cache_write ×1.25 · cache_read ×0.1
@@ -32,7 +33,11 @@ CEILING_HINT = 120_000      # потолок из phases/5-subagents.md, для 
 
 def logs_dir_for(project_path):
     p = os.path.abspath(os.path.expanduser(project_path))
-    return os.path.join(os.path.expanduser("~/.claude/projects"), p.replace("/", "-"))
+    # Все три разделителя, а не только «/»: на Windows путь приходит как C:\Users\x,
+    # и «C:\...» осталось бы абсолютным — os.path.join тогда отбрасывает первый аргумент
+    # и замер молча уходит искать логи в самой папке проекта.
+    slug = p.replace("\\", "-").replace("/", "-").replace(":", "-")
+    return os.path.join(os.path.expanduser("~/.claude/projects"), slug)
 
 
 def parse_ts(s):
@@ -46,7 +51,7 @@ def parse_ts(s):
 
 def load(path):
     rows = []
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line:
@@ -123,6 +128,12 @@ def analyse(path, label):
 
 
 def main():
+    # Отчёт — кириллица и «█»; на Windows консоль по умолчанию не utf-8,
+    # и печать полосы расхода падала бы UnicodeEncodeError на готовых цифрах.
+    # stderr — потому что подсказки и «нет логов» уходят туда через sys.exit.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
     if len(sys.argv) < 2:
         sys.exit(__doc__)
     d = logs_dir_for(sys.argv[1])
@@ -155,7 +166,7 @@ def main():
 
     metas = {}
     for mf in glob.glob(os.path.join(sub_dir, "subagents", "*.meta.json")):
-        with open(mf) as f:
+        with open(mf, encoding="utf-8") as f:
             metas[os.path.basename(mf)[:-10]] = json.load(f)
 
     results = [analyse(main_log, "Оркестратор")]


### PR DESCRIPTION
`tools/measure-run.py` на Windows не доходит до отчёта. Три места, и все три молчат по-своему.

**Каталог логов.** Путь приходит как `C:\Users\x`, `replace("/", "-")` его не трогает, строка остаётся абсолютной — и `os.path.join` в этом случае отбрасывает первый аргумент. Скрипт уходит искать `.jsonl` в самой папке проекта. Она существует, `os.path.isdir` проходит, наружу выходит «нет .jsonl» — читается как пустой прогон, а не как сломанный путь.

Теперь дефисом заменяются оба разделителя и двоеточие диска. На POSIX результат прежний, байт в байт: замены `\` и `:` там ни во что не попадают.

**Кодировка файлов.** `open()` без `encoding` берёт системную кодировку; на русской Windows это cp1251, и первый же лог с кириллицей роняет разбор `UnicodeDecodeError`. Логи Claude Code всегда utf-8 — так и открываем.

**Кодировка вывода.** Отчёт печатает кириллицу и `█`, которого в cp1251 нет: полоса «Структура расхода» падала `UnicodeEncodeError` уже после того, как всё посчитано. `stderr` тоже — через `sys.exit` туда уходят подсказка по запуску и «нет логов».

Проверено на Windows 10, Python 3.12, Git Bash — на прогоне из 41 контекста: полный отчёт, обе ветки `sys.exit`, запуск без аргументов. Диф — один файл, четыре места, поведение на macOS и Linux не меняется.

Спасибо за autopilot — читал ради арифметики потолка контекста в `phases/5-subagents.md`, заодно попробовал замер.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
